### PR TITLE
#156937486 Feature Admin Order History and Details UI

### DIFF
--- a/UI/admin-menu.html
+++ b/UI/admin-menu.html
@@ -59,7 +59,7 @@
         </div>
         <div class="sidenav-body">
           <a href="./dashboard.html" class="menu-item">Dashboard</a>
-          <a href="#" class="menu-item">Order History</a>
+          <a href="./admin-order-history.html" class="menu-item">Order History</a>
           <a href="./meals.html" class="menu-item">Meals</a>
           <a href="#" class="menu-item active">Menu</a>
         </div>

--- a/UI/admin-order-history.html
+++ b/UI/admin-order-history.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="stylesheet" href="./assets/css/style.css">
+  <title>Book a Meal</title>
+</head>
+
+<body class="admin">
+  <div class="header">
+    <div class="navbar white-navbar">
+      <div class="menu-control d-none-md">
+        <a href="#sidenav" class="d-none-md">
+          <img src="./assets/img/toggler.png" alt="toggler">
+        </a>
+      </div>
+      <div class="page-title">
+        <h3>
+          <a href="./index.html">BOOK-A-MEAL</a>
+        </h3>
+      </div>
+      <div class="navlinks admin-nav">
+        <div class="dropdown notification">
+          <a href="#" id="dropdown-toggler" class="link">
+            <img src="./assets/img/notif.png" alt="notification bell" id="dropdown-img">
+          </a>
+          <div class="dropdown-content" id="dropdown-content">
+            <a href="#" class="read">User just ordered your menu</a>
+            <a href="#">User just ordered your menu</a>
+            <a href="#" class="read">User just ordered your menu</a>
+            <a href="#">User just ordered your menu</a>
+            <a href="#">User just ordered your menu</a>
+            <a href="#">User just ordered your menu</a>
+            <a href="#" class="read">User just ordered your menu</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="content">
+    <div class="sidenav" id="sidenav">
+      <div class="sidenav-content">
+        <div class="sidenav-header">
+          <div class="close d-none-md">
+            <a href="#" aria-hidden="true">&times;</a>
+          </div>
+          <div class="sidenav-title">
+            <div class="username-circle">
+              <p>I</p>
+            </div>
+            <p>Iveren</p>
+            <span>
+              <a href="./login.html">Logout</a>
+            </span>
+          </div>
+        </div>
+        <div class="sidenav-body">
+          <a href="./dashboard.html" class="menu-item active">Dashboard</a>
+          <a href="#" class="menu-item">Order History</a>
+          <a href="./meals.html" class="menu-item">Meals</a>
+          <a href="./admin-menu.html" class="menu-item">Menu</a>
+        </div>
+      </div>
+    </div>
+    <div class="main-wrapper dashboard">
+      <div class="order-history">
+        <div class="page-heading">
+          <h2>Order History</h2>
+          <hr>
+        </div>
+        <div class="pills">
+          <div class="order-history-pill admin-order-history-pill">
+            <a href="#" id="pill-click">
+              <div class="order-history-header">
+                <h3>#1234567</h3>
+                <h3>13/12/17 12:38pm</h3>
+              </div>
+              <hr>
+              <div class="order-history-footer">
+                <h4>Status:
+                  <span class="warning">Pending</span>
+                </h4>
+                <h2>&#8358;1200.00</h2>
+              </div>
+            </a>
+          </div>
+          <div class="order-history-pill admin-order-history-pill">
+            <a href="#" id="pill-click">
+              <div class="order-history-header">
+                <h3>#1234567</h3>
+                <h3>13/12/17 12:38pm</h3>
+              </div>
+              <hr>
+              <div class="order-history-footer">
+                <h4>Status:
+                  <span class="danger">Canceled</span>
+                </h4>
+                <h2>&#8358;1200.00</h2>
+              </div>
+            </a>
+          </div>
+          <div class="order-history-pill admin-order-history-pill">
+            <a href="#" id="pill-click">
+              <div class="order-history-header">
+                <h3>#1234567</h3>
+                <h3>13/12/17 12:38pm</h3>
+              </div>
+              <hr>
+              <div class="order-history-footer">
+                <h4>Status:
+                  <span class="success">Delivered</span>
+                </h4>
+                <h2>&#8358;1200.00</h2>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal" id="order-details-modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div class="modal-title">
+          <h4 id="modal-title-h3">Order #12345678 -
+            <span class="warning text-small">Pending</span>
+          </h4>
+        </div>
+        <div class="close">
+          <a href="#" aria-hidden="true" id="modal-close-icon">&times;</a>
+        </div>
+      </div>
+      <hr>
+      <div class="modal-body order-confirmation order-details">
+        <p class="order-date text-center">15/12/2017 07:45pm</p>
+        <div class="order-summary">
+          <div>
+            <p>Mrs. Tola Olanipekun</p>
+            <p>4, Church Street, Yaba</p>
+          </div>
+          <div>
+            <p>2x</p>
+            <p>Jollof Rice</p>
+            <p>&#8358;300.00</p>
+          </div>
+          <div>
+            <p>1x</p>
+            <p>Basmati Rice</p>
+            <p>&#8358;800.00</p>
+          </div>
+        </div>
+        <div class="order-amount">
+          <div>
+            <p>Subtotal</p>
+            <p>&#8358;1100.00</p>
+          </div>
+          <div>
+            <p>Delivery Fee</p>
+            <p>&#8358;600.00</p>
+          </div>
+          <div>
+            <p>Including VAT</p>
+            <p>&#8358;13.29</p>
+          </div>
+          <div>
+            <p>Total</p>
+            <h1>&#8358;1700.00</h1>
+          </div>
+        </div>
+        <div class="d-flex-row">
+          <button class="btn btn-sec order-details-btn">Update</button>
+          <button class="btn btn-sec-danger order-details-btn">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  </div>
+  <div class="footer">
+    <p>&copy; 2018. Iveren Shaguy</p>
+  </div>
+  <script src="./assets/js/main.js"></script>
+</body>
+
+</html>

--- a/UI/assets/css/style.css
+++ b/UI/assets/css/style.css
@@ -213,7 +213,10 @@
           display: block;
           margin: 0.7em 0.7em 0.7em 0; }
     .modal-content .modal-body {
-      padding: 20px; }
+      padding: 20px 30px; }
+      .modal-content .modal-body.order-confirmation {
+        margin-top: 0;
+        width: 100%; }
       .modal-content .modal-body .delete-meal {
         text-align: center; }
         .modal-content .modal-body .delete-meal p {
@@ -946,6 +949,11 @@ hr {
     display: flex;
     flex-direction: column;
     align-content: space-around; }
+  .admin .main-wrapper {
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%; }
   @media (min-width: 767.98px) {
     .admin {
       display: flex;

--- a/UI/assets/js/main.js
+++ b/UI/assets/js/main.js
@@ -5,12 +5,14 @@ window.onload = function () {
   const mealCardBtns = document.getElementsByClassName('meal-card-btn');
   const mealModal = document.getElementById('meal-modal');
   const notifModal = document.getElementById('notif-modal');
+  const orderDetailsModal = document.getElementById('order-details-modal');
   const modalTitle = document.getElementById('modal-title-h3');
   const modalBody = document.getElementsByClassName('modal-body')[0];
   const menuModalBtn = document.getElementById('menu-modal-btn');
   const menuModal = document.getElementById('menu-modal');
   const dropdowns = document.getElementsByClassName('dropdown');
   const checkoutBtn = document.getElementById('checkout');
+  const adminOrderHistoryPill = document.getElementsByClassName('admin-order-history-pill');
 
   // javscript closest polyfill
   if (!Element.prototype.matches)
@@ -37,6 +39,12 @@ window.onload = function () {
       if (e.target === e.currentTarget) {
         redirect('./order-confirmation.html');
       }
+    });
+  }
+
+  if (adminOrderHistoryPill) for (let i = 0; i < adminOrderHistoryPill.length; i++) {
+    adminOrderHistoryPill[i].addEventListener('click', function (e) {
+      orderDetailsModal.classList.add('show');
     });
   }
 

--- a/UI/assets/scss/modules/_modals.scss
+++ b/UI/assets/scss/modules/_modals.scss
@@ -100,7 +100,12 @@
     }
 
     .modal-body {
-      padding: 20px;
+      padding: 20px 30px;
+
+      &.order-confirmation {
+        margin-top: 0;
+        width: 100%;
+      }
 
       .delete-meal {
         text-align: center;

--- a/UI/assets/scss/style.scss
+++ b/UI/assets/scss/style.scss
@@ -285,6 +285,13 @@ hr {
     align-content:  space-around;
   }
 
+  .main-wrapper {
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+  }
+
 
   @media (min-width: 767.98px) {
     display: flex;

--- a/UI/dashboard.html
+++ b/UI/dashboard.html
@@ -59,7 +59,7 @@
         </div>
         <div class="sidenav-body">
           <a href="#" class="menu-item active">Dashboard</a>
-          <a href="#" class="menu-item">Order History</a>
+          <a href="./admin-order-history.html" class="menu-item">Order History</a>
           <a href="./meals.html" class="menu-item">Meals</a>
           <a href="./admin-menu.html" class="menu-item">Menu</a>
         </div>
@@ -96,44 +96,54 @@
               <th>Status</th>
             </thead>
             <tr>
-              <td>1</td>
-              <td>Maria Anders</td>
-              <td>Germany</td>
-              <td>Alfreds Futterkiste</td>
-              <td>Maria Anders</td>
-              <td>Germany</td>
+              <td>11234</td>
+              <td>Rice Meal</td>
+              <td>Mrs. Tola</td>
+              <td>&#8358;2100</td>
+              <td>21/04/17 8:50pm</td>
+              <td>
+                <span class="success">Delivered</span>
+              </td>
             </tr>
             <tr>
-              <td>2</td>
-              <td>Christina Berglund</td>
-              <td>Sweden</td>
-              <td>Berglunds snabbköp</td>
-              <td>Christina Berglund</td>
-              <td>Sweden</td>
+              <td>31234</td>
+              <td>Kids'r It Pack</td>
+              <td>Rita Opara</td>
+              <td>&#8358;2100</td>
+              <td>21/04/17 8:50pm</td>
+              <td>
+                <span class="danger">Canceled</span>
+              </td>
             </tr>
             <tr>
-              <td>3</td>
-              <td>Francisco Chang</td>
-              <td>Mexico</td>
-              <td>Centro comercial Moctezuma</td>
-              <td>Francisco Chang</td>
-              <td>Mexico</td>
+              <td>11534</td>
+              <td>Revenge Body Meal</td>
+              <td>Uche Emodi</td>
+              <td>&#8358;2100</td>
+              <td>21/04/17 8:50pm</td>
+              <td>
+                <span class="success">Delivered</span>
+              </td>
             </tr>
             <tr>
-              <td>4</td>
-              <td>Roland Mendel</td>
-              <td>Austria</td>
-              <td>Ernst Handel</td>
-              <td>Roland Mendel</td>
-              <td>Austria</td>
+              <td>41284</td>
+              <td>Meat Loaf</td>
+              <td>Mrs. Tola</td>
+              <td>&#8358;2100</td>
+              <td>21/04/17 8:50pm</td>
+              <td>
+                <span class="warning">Pending</span>
+              </td>
             </tr>
             <tr>
-              <td>5</td>
-              <td>Helen Bennett</td>
-              <td>UK</td>
-              <td>Island Trading</td>
-              <td>Helen Bennett</td>
-              <td>UK</td>
+              <td>14934</td>
+              <td>Hungary Man Pack</td>
+              <td>Tunde Agoro</td>
+              <td>&#8358;3000</td>
+              <td>13/04/18 8:59am</td>
+              <td>
+                <span class="success">Delivered</span>
+              </td>
             </tr>
           </table>
         </div>

--- a/UI/meals.html
+++ b/UI/meals.html
@@ -59,7 +59,7 @@
         </div>
         <div class="sidenav-body">
           <a href="./dashboard.html" class="menu-item">Dashboard</a>
-          <a href="#" class="menu-item">Order History</a>
+          <a href="./admin-order-history.html" class="menu-item">Order History</a>
           <a href="#" class="menu-item active">Meals</a>
           <a href="./admin-menu.html" class="menu-item">Menu</a>
         </div>


### PR DESCRIPTION
#### What does this PR do?
This pull request implements admin order history and order details UI
#### Description of Task to be completed?
The admin should be able to see the history of orders on the platform and the order details for each one in a modal when any of them is clicked
#### How should this be manually tested?
N/A
#### What are the relevant pivotal tracker stories?
#156937486
#### Any background context you want to add?
None
#### Screenshots
![admin-order-details](https://user-images.githubusercontent.com/22734663/39051316-31aad642-44a0-11e8-8ba6-5ea70a6efa0d.png)
